### PR TITLE
Avoid backslash line termination with builtin any()

### DIFF
--- a/SudokuSolver.py
+++ b/SudokuSolver.py
@@ -60,9 +60,9 @@ class Solver:
                     if arr[i + row][j + col] == num:
                         return True
             return False
-        return not used_in_row(arr, row, num) \
-               and not used_in_col(arr, col, num) and \
-               not used_in_box(arr, row - row % 3, col - col % 3, num)
+        return not any(used_in_row(arr, row, num),
+                       used_in_col(arr, col, num),
+                       used_in_box(arr, row - row % 3, col - col % 3, num))
 
     def solve_sudoku(self, arr):
         l = [0, 0]


### PR DESCRIPTION
PEP8 recommends avoiding backslash line termination in Python because a whitespace to the right of the backslash breaks the script on a change that is invisible to the reader.